### PR TITLE
Enable Internationalization plugin (English and Spanish)

### DIFF
--- a/api/config/sync/admin-role.strapi-editor.json
+++ b/api/config/sync/admin-role.strapi-editor.json
@@ -5,6 +5,7 @@
   "permissions": [
     {
       "action": "plugin::content-manager.explorer.create",
+      "actionParameters": null,
       "subject": "api::project.project",
       "properties": {
         "fields": [
@@ -12,25 +13,11 @@
           "description"
         ]
       },
-      "conditions": [],
-      "actionParameters": null
-    },
-    {
-      "action": "plugin::content-manager.explorer.delete",
-      "subject": "api::project.project",
-      "properties": {},
-      "conditions": [],
-      "actionParameters": null
-    },
-    {
-      "action": "plugin::content-manager.explorer.publish",
-      "subject": "api::project.project",
-      "properties": {},
-      "conditions": [],
-      "actionParameters": null
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.read",
+      "actionParameters": null,
       "subject": "api::project.project",
       "properties": {
         "fields": [
@@ -38,11 +25,11 @@
           "description"
         ]
       },
-      "conditions": [],
-      "actionParameters": null
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.update",
+      "actionParameters": null,
       "subject": "api::project.project",
       "properties": {
         "fields": [
@@ -50,50 +37,49 @@
           "description"
         ]
       },
-      "conditions": [],
-      "actionParameters": null
+      "conditions": []
     },
     {
       "action": "plugin::upload.assets.copy-link",
+      "actionParameters": null,
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": null
+      "conditions": []
     },
     {
       "action": "plugin::upload.assets.create",
+      "actionParameters": null,
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": null
+      "conditions": []
     },
     {
       "action": "plugin::upload.assets.download",
+      "actionParameters": null,
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": null
+      "conditions": []
     },
     {
       "action": "plugin::upload.assets.update",
+      "actionParameters": null,
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": null
+      "conditions": []
     },
     {
       "action": "plugin::upload.configure-view",
+      "actionParameters": null,
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": null
+      "conditions": []
     },
     {
       "action": "plugin::upload.read",
+      "actionParameters": null,
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": null
+      "conditions": []
     }
   ]
 }

--- a/api/config/sync/admin-role.strapi-super-admin.json
+++ b/api/config/sync/admin-role.strapi-super-admin.json
@@ -5,6 +5,7 @@
   "permissions": [
     {
       "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
       "subject": "api::contextual-risk-category.contextual-risk-category",
       "properties": {
         "fields": [
@@ -13,27 +14,41 @@
           "display_order",
           "contextual_risks",
           "slug"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
       "subject": "api::contextual-risk-category.contextual-risk-category",
-      "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "properties": {
+        "locales": [
+          "en",
+          "es"
+        ]
+      },
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
       "subject": "api::contextual-risk-category.contextual-risk-category",
-      "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "properties": {
+        "locales": [
+          "en",
+          "es"
+        ]
+      },
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
       "subject": "api::contextual-risk-category.contextual-risk-category",
       "properties": {
         "fields": [
@@ -42,13 +57,17 @@
           "display_order",
           "contextual_risks",
           "slug"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
       "subject": "api::contextual-risk-category.contextual-risk-category",
       "properties": {
         "fields": [
@@ -57,69 +76,98 @@
           "display_order",
           "contextual_risks",
           "slug"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
       "subject": "api::contextual-risk.contextual-risk",
       "properties": {
         "fields": [
           "title",
           "description",
           "display_order",
-          "contextual_risk_category"
+          "contextual_risk_category",
+          "project_risk_description"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
       "subject": "api::contextual-risk.contextual-risk",
-      "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "properties": {
+        "locales": [
+          "en",
+          "es"
+        ]
+      },
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
       "subject": "api::contextual-risk.contextual-risk",
-      "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "properties": {
+        "locales": [
+          "en",
+          "es"
+        ]
+      },
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
       "subject": "api::contextual-risk.contextual-risk",
       "properties": {
         "fields": [
           "title",
           "description",
           "display_order",
-          "contextual_risk_category"
+          "contextual_risk_category",
+          "project_risk_description"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
       "subject": "api::contextual-risk.contextual-risk",
       "properties": {
         "fields": [
           "title",
           "description",
           "display_order",
-          "contextual_risk_category"
+          "contextual_risk_category",
+          "project_risk_description"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
       "subject": "api::pcb-category.pcb-category",
       "properties": {
         "fields": [
@@ -128,27 +176,41 @@
           "pcbs",
           "description",
           "slug"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
       "subject": "api::pcb-category.pcb-category",
-      "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "properties": {
+        "locales": [
+          "en",
+          "es"
+        ]
+      },
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
       "subject": "api::pcb-category.pcb-category",
-      "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "properties": {
+        "locales": [
+          "en",
+          "es"
+        ]
+      },
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
       "subject": "api::pcb-category.pcb-category",
       "properties": {
         "fields": [
@@ -157,13 +219,17 @@
           "pcbs",
           "description",
           "slug"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
       "subject": "api::pcb-category.pcb-category",
       "properties": {
         "fields": [
@@ -172,13 +238,17 @@
           "pcbs",
           "description",
           "slug"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
       "subject": "api::pcb.pcb",
       "properties": {
         "fields": [
@@ -187,27 +257,41 @@
           "pcb_category",
           "description",
           "input"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
       "subject": "api::pcb.pcb",
-      "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "properties": {
+        "locales": [
+          "en",
+          "es"
+        ]
+      },
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
       "subject": "api::pcb.pcb",
-      "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "properties": {
+        "locales": [
+          "en",
+          "es"
+        ]
+      },
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
       "subject": "api::pcb.pcb",
       "properties": {
         "fields": [
@@ -216,13 +300,17 @@
           "pcb_category",
           "description",
           "input"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
       "subject": "api::pcb.pcb",
       "properties": {
         "fields": [
@@ -231,13 +319,17 @@
           "pcb_category",
           "description",
           "input"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
       "subject": "api::project.project",
       "properties": {
         "fields": [
@@ -246,27 +338,41 @@
           "risks",
           "author",
           "pcbs"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
       "subject": "api::project.project",
-      "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "properties": {
+        "locales": [
+          "en",
+          "es"
+        ]
+      },
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
       "subject": "api::project.project",
-      "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "properties": {
+        "locales": [
+          "en",
+          "es"
+        ]
+      },
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
       "subject": "api::project.project",
       "properties": {
         "fields": [
@@ -275,13 +381,17 @@
           "risks",
           "author",
           "pcbs"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
       "subject": "api::project.project",
       "properties": {
         "fields": [
@@ -290,230 +400,234 @@
           "risks",
           "author",
           "pcbs"
+        ],
+        "locales": [
+          "en",
+          "es"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::api-tokens.access",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::api-tokens.create",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::api-tokens.delete",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::api-tokens.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::api-tokens.regenerate",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::api-tokens.update",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::marketplace.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::project-settings.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::project-settings.update",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::roles.create",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::roles.delete",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::roles.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::roles.update",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::transfer.tokens.access",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::transfer.tokens.create",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::transfer.tokens.delete",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::transfer.tokens.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::transfer.tokens.regenerate",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::transfer.tokens.update",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::users.create",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::users.delete",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::users.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::users.update",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::webhooks.create",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::webhooks.delete",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::webhooks.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "admin::webhooks.update",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::config-sync.menu-link",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::config-sync.settings.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.collection-types.configure-view",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.components.configure-layout",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
       "subject": "plugin::users-permissions.user",
       "properties": {
         "fields": [
@@ -528,18 +642,18 @@
           "role"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
       "subject": "plugin::users-permissions.user",
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
       "subject": "plugin::users-permissions.user",
       "properties": {
         "fields": [
@@ -554,11 +668,11 @@
           "role"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
       "subject": "plugin::users-permissions.user",
       "properties": {
         "fields": [
@@ -573,218 +687,217 @@
           "role"
         ]
       },
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-manager.single-types.configure-view",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::content-type-builder.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::documentation.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::documentation.settings.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::documentation.settings.regenerate",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::documentation.settings.update",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::email.settings.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::i18n.locale.create",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::i18n.locale.delete",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::i18n.locale.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::i18n.locale.update",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::import-export-entries.export",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::import-export-entries.import",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::upload.assets.copy-link",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::upload.assets.create",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::upload.assets.download",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::upload.assets.update",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::upload.configure-view",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::upload.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::upload.settings.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::users-permissions.advanced-settings.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::users-permissions.advanced-settings.update",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::users-permissions.email-templates.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::users-permissions.email-templates.update",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::users-permissions.providers.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::users-permissions.providers.update",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::users-permissions.roles.create",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::users-permissions.roles.delete",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::users-permissions.roles.read",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     },
     {
       "action": "plugin::users-permissions.roles.update",
+      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": [],
-      "actionParameters": {}
+      "conditions": []
     }
   ]
 }

--- a/api/config/sync/core-store.plugin_content_manager_configuration_content_types##api##contextual-risk.contextual-risk.json
+++ b/api/config/sync/core-store.plugin_content_manager_configuration_content_types##api##contextual-risk.contextual-risk.json
@@ -77,6 +77,20 @@
           "sortable": true
         }
       },
+      "project_risk_description": {
+        "edit": {
+          "label": "project_risk_description",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "project_risk_description",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -137,6 +151,12 @@
       }
     },
     "layouts": {
+      "list": [
+        "id",
+        "title",
+        "display_order",
+        "contextual_risk_category"
+      ],
       "edit": [
         [
           {
@@ -161,13 +181,13 @@
             "name": "description",
             "size": 12
           }
+        ],
+        [
+          {
+            "name": "project_risk_description",
+            "size": 12
+          }
         ]
-      ],
-      "list": [
-        "id",
-        "title",
-        "display_order",
-        "contextual_risk_category"
       ]
     }
   },

--- a/api/config/sync/i18n-locale.es.json
+++ b/api/config/sync/i18n-locale.es.json
@@ -1,0 +1,4 @@
+{
+  "name": "Spanish (es)",
+  "code": "es"
+}

--- a/api/src/api/contextual-risk-category/content-types/contextual-risk-category/schema.json
+++ b/api/src/api/contextual-risk-category/content-types/contextual-risk-category/schema.json
@@ -10,19 +10,38 @@
   "options": {
     "draftAndPublish": true
   },
-  "pluginOptions": {},
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
   "attributes": {
     "title": {
       "type": "string",
       "required": true,
-      "unique": true
+      "unique": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "description": {
       "type": "richtext",
-      "required": true
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "display_order": {
-      "type": "integer"
+      "type": "integer",
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
     },
     "contextual_risks": {
       "type": "relation",

--- a/api/src/api/contextual-risk-category/documentation/1.0.0/contextual-risk-category.json
+++ b/api/src/api/contextual-risk-category/documentation/1.0.0/contextual-risk-category.json
@@ -503,5 +503,97 @@
       ],
       "operationId": "delete/contextual-risk-categories/{id}"
     }
+  },
+  "/contextual-risk-categories/{id}/localizations": {
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ContextualRiskCategoryLocalizationResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Contextual-risk-category"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "post/contextual-risk-categories/{id}/localizations",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ContextualRiskCategoryLocalizationRequest"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/api/src/api/contextual-risk/content-types/contextual-risk/schema.json
+++ b/api/src/api/contextual-risk/content-types/contextual-risk/schema.json
@@ -10,19 +10,38 @@
   "options": {
     "draftAndPublish": true
   },
-  "pluginOptions": {},
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
   "attributes": {
     "title": {
       "type": "string",
-      "required": true
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "description": {
       "type": "richtext",
-      "required": true
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "display_order": {
       "type": "integer",
-      "required": true
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
     },
     "contextual_risk_category": {
       "type": "relation",
@@ -32,7 +51,12 @@
     },
     "project_risk_description": {
       "type": "richtext",
-      "required": true
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     }
   }
 }

--- a/api/src/api/contextual-risk/documentation/1.0.0/contextual-risk.json
+++ b/api/src/api/contextual-risk/documentation/1.0.0/contextual-risk.json
@@ -503,5 +503,97 @@
       ],
       "operationId": "delete/contextual-risks/{id}"
     }
+  },
+  "/contextual-risks/{id}/localizations": {
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ContextualRiskLocalizationResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Contextual-risk"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "post/contextual-risks/{id}/localizations",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ContextualRiskLocalizationRequest"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/api/src/api/pcb-category/content-types/pcb-category/schema.json
+++ b/api/src/api/pcb-category/content-types/pcb-category/schema.json
@@ -10,15 +10,29 @@
   "options": {
     "draftAndPublish": true
   },
-  "pluginOptions": {},
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
   "attributes": {
     "title": {
       "type": "string",
       "required": true,
-      "unique": false
+      "unique": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "display_order": {
-      "type": "integer"
+      "type": "integer",
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
     },
     "pcbs": {
       "type": "relation",
@@ -28,7 +42,12 @@
     },
     "description": {
       "type": "richtext",
-      "required": true
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "slug": {
       "type": "uid",

--- a/api/src/api/pcb-category/documentation/1.0.0/pcb-category.json
+++ b/api/src/api/pcb-category/documentation/1.0.0/pcb-category.json
@@ -503,5 +503,97 @@
       ],
       "operationId": "delete/pcb-categories/{id}"
     }
+  },
+  "/pcb-categories/{id}/localizations": {
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PcbCategoryLocalizationResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Pcb-category"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "post/pcb-categories/{id}/localizations",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PcbCategoryLocalizationRequest"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/api/src/api/pcb/content-types/pcb/schema.json
+++ b/api/src/api/pcb/content-types/pcb/schema.json
@@ -10,14 +10,28 @@
   "options": {
     "draftAndPublish": true
   },
-  "pluginOptions": {},
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
   "attributes": {
     "title": {
       "type": "string",
-      "required": true
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "display_order": {
-      "type": "integer"
+      "type": "integer",
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
     },
     "pcb_category": {
       "type": "relation",
@@ -27,11 +41,21 @@
     },
     "description": {
       "type": "richtext",
-      "required": true
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "input": {
       "type": "json",
-      "required": true
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     }
   }
 }

--- a/api/src/api/pcb/documentation/1.0.0/pcb.json
+++ b/api/src/api/pcb/documentation/1.0.0/pcb.json
@@ -503,5 +503,97 @@
       ],
       "operationId": "delete/pcbs/{id}"
     }
+  },
+  "/pcbs/{id}/localizations": {
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PcbLocalizationResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Pcb"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "post/pcbs/{id}/localizations",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PcbLocalizationRequest"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/api/src/api/project/content-types/project/schema.json
+++ b/api/src/api/project/content-types/project/schema.json
@@ -10,18 +10,37 @@
   "options": {
     "draftAndPublish": true
   },
-  "pluginOptions": {},
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
   "attributes": {
     "name": {
       "type": "string",
-      "required": true
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "description": {
       "type": "richtext",
-      "required": true
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "risks": {
-      "type": "json"
+      "type": "json",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "author": {
       "type": "relation",
@@ -29,7 +48,12 @@
       "target": "plugin::users-permissions.user"
     },
     "pcbs": {
-      "type": "json"
+      "type": "json",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     }
   }
 }

--- a/api/src/api/project/documentation/1.0.0/project.json
+++ b/api/src/api/project/documentation/1.0.0/project.json
@@ -503,5 +503,97 @@
       ],
       "operationId": "delete/projects/{id}"
     }
+  },
+  "/projects/{id}/localizations": {
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectLocalizationResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Project"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "post/projects/{id}/localizations",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProjectLocalizationRequest"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/api/types/generated/contentTypes.d.ts
+++ b/api/types/generated/contentTypes.d.ts
@@ -688,16 +688,45 @@ export interface ApiContextualRiskContextualRisk extends Schema.CollectionType {
   options: {
     draftAndPublish: true;
   };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
   attributes: {
-    title: Attribute.String & Attribute.Required;
-    description: Attribute.RichText & Attribute.Required;
-    display_order: Attribute.Integer & Attribute.Required;
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    description: Attribute.RichText &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    display_order: Attribute.Integer &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }>;
     contextual_risk_category: Attribute.Relation<
       'api::contextual-risk.contextual-risk',
       'manyToOne',
       'api::contextual-risk-category.contextual-risk-category'
     >;
-    project_risk_description: Attribute.RichText & Attribute.Required;
+    project_risk_description: Attribute.RichText &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
@@ -713,6 +742,12 @@ export interface ApiContextualRiskContextualRisk extends Schema.CollectionType {
       'admin::user'
     > &
       Attribute.Private;
+    localizations: Attribute.Relation<
+      'api::contextual-risk.contextual-risk',
+      'oneToMany',
+      'api::contextual-risk.contextual-risk'
+    >;
+    locale: Attribute.String;
   };
 }
 
@@ -728,10 +763,33 @@ export interface ApiContextualRiskCategoryContextualRiskCategory
   options: {
     draftAndPublish: true;
   };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
   attributes: {
-    title: Attribute.String & Attribute.Required & Attribute.Unique;
-    description: Attribute.RichText & Attribute.Required;
-    display_order: Attribute.Integer;
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.Unique &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    description: Attribute.RichText &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    display_order: Attribute.Integer &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }>;
     contextual_risks: Attribute.Relation<
       'api::contextual-risk-category.contextual-risk-category',
       'oneToMany',
@@ -756,6 +814,12 @@ export interface ApiContextualRiskCategoryContextualRiskCategory
       'admin::user'
     > &
       Attribute.Private;
+    localizations: Attribute.Relation<
+      'api::contextual-risk-category.contextual-risk-category',
+      'oneToMany',
+      'api::contextual-risk-category.contextual-risk-category'
+    >;
+    locale: Attribute.String;
   };
 }
 
@@ -770,16 +834,44 @@ export interface ApiPcbPcb extends Schema.CollectionType {
   options: {
     draftAndPublish: true;
   };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
   attributes: {
-    title: Attribute.String & Attribute.Required;
-    display_order: Attribute.Integer;
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    display_order: Attribute.Integer &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }>;
     pcb_category: Attribute.Relation<
       'api::pcb.pcb',
       'manyToOne',
       'api::pcb-category.pcb-category'
     >;
-    description: Attribute.RichText & Attribute.Required;
-    input: Attribute.JSON & Attribute.Required;
+    description: Attribute.RichText &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    input: Attribute.JSON &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
@@ -787,6 +879,12 @@ export interface ApiPcbPcb extends Schema.CollectionType {
       Attribute.Private;
     updatedBy: Attribute.Relation<'api::pcb.pcb', 'oneToOne', 'admin::user'> &
       Attribute.Private;
+    localizations: Attribute.Relation<
+      'api::pcb.pcb',
+      'oneToMany',
+      'api::pcb.pcb'
+    >;
+    locale: Attribute.String;
   };
 }
 
@@ -801,15 +899,37 @@ export interface ApiPcbCategoryPcbCategory extends Schema.CollectionType {
   options: {
     draftAndPublish: true;
   };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
   attributes: {
-    title: Attribute.String & Attribute.Required;
-    display_order: Attribute.Integer;
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    display_order: Attribute.Integer &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }>;
     pcbs: Attribute.Relation<
       'api::pcb-category.pcb-category',
       'oneToMany',
       'api::pcb.pcb'
     >;
-    description: Attribute.RichText & Attribute.Required;
+    description: Attribute.RichText &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     slug: Attribute.UID<'api::pcb-category.pcb-category', 'title'>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
@@ -826,6 +946,12 @@ export interface ApiPcbCategoryPcbCategory extends Schema.CollectionType {
       'admin::user'
     > &
       Attribute.Private;
+    localizations: Attribute.Relation<
+      'api::pcb-category.pcb-category',
+      'oneToMany',
+      'api::pcb-category.pcb-category'
+    >;
+    locale: Attribute.String;
   };
 }
 
@@ -840,16 +966,43 @@ export interface ApiProjectProject extends Schema.CollectionType {
   options: {
     draftAndPublish: true;
   };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
   attributes: {
-    name: Attribute.String & Attribute.Required;
-    description: Attribute.RichText & Attribute.Required;
-    risks: Attribute.JSON;
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    description: Attribute.RichText &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    risks: Attribute.JSON &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     author: Attribute.Relation<
       'api::project.project',
       'oneToOne',
       'plugin::users-permissions.user'
     >;
-    pcbs: Attribute.JSON;
+    pcbs: Attribute.JSON &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
@@ -865,6 +1018,12 @@ export interface ApiProjectProject extends Schema.CollectionType {
       'admin::user'
     > &
       Attribute.Private;
+    localizations: Attribute.Relation<
+      'api::project.project',
+      'oneToMany',
+      'api::project.project'
+    >;
+    locale: Attribute.String;
   };
 }
 

--- a/client/src/types/generated/contextual-risk-category.ts
+++ b/client/src/types/generated/contextual-risk-category.ts
@@ -20,6 +20,8 @@ import type {
   ContextualRiskCategoryResponse,
   ContextualRiskCategoryRequest,
   GetContextualRiskCategoriesIdParams,
+  ContextualRiskCategoryLocalizationResponse,
+  ContextualRiskCategoryLocalizationRequest,
 } from "./strapi.schemas";
 import { API } from "../../services/api/index";
 import type { ErrorType } from "../../services/api/index";
@@ -335,6 +337,70 @@ export const useDeleteContextualRiskCategoriesId = <
   >;
 }) => {
   const mutationOptions = getDeleteContextualRiskCategoriesIdMutationOptions(options);
+
+  return useMutation(mutationOptions);
+};
+export const postContextualRiskCategoriesIdLocalizations = (
+  id: number,
+  contextualRiskCategoryLocalizationRequest: ContextualRiskCategoryLocalizationRequest,
+) => {
+  return API<ContextualRiskCategoryLocalizationResponse>({
+    url: `/contextual-risk-categories/${id}/localizations`,
+    method: "post",
+    headers: { "Content-Type": "application/json" },
+    data: contextualRiskCategoryLocalizationRequest,
+  });
+};
+
+export const getPostContextualRiskCategoriesIdLocalizationsMutationOptions = <
+  TError = ErrorType<Error>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postContextualRiskCategoriesIdLocalizations>>,
+    TError,
+    { id: number; data: ContextualRiskCategoryLocalizationRequest },
+    TContext
+  >;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof postContextualRiskCategoriesIdLocalizations>>,
+  TError,
+  { id: number; data: ContextualRiskCategoryLocalizationRequest },
+  TContext
+> => {
+  const { mutation: mutationOptions } = options ?? {};
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof postContextualRiskCategoriesIdLocalizations>>,
+    { id: number; data: ContextualRiskCategoryLocalizationRequest }
+  > = (props) => {
+    const { id, data } = props ?? {};
+
+    return postContextualRiskCategoriesIdLocalizations(id, data);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type PostContextualRiskCategoriesIdLocalizationsMutationResult = NonNullable<
+  Awaited<ReturnType<typeof postContextualRiskCategoriesIdLocalizations>>
+>;
+export type PostContextualRiskCategoriesIdLocalizationsMutationBody =
+  ContextualRiskCategoryLocalizationRequest;
+export type PostContextualRiskCategoriesIdLocalizationsMutationError = ErrorType<Error>;
+
+export const usePostContextualRiskCategoriesIdLocalizations = <
+  TError = ErrorType<Error>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postContextualRiskCategoriesIdLocalizations>>,
+    TError,
+    { id: number; data: ContextualRiskCategoryLocalizationRequest },
+    TContext
+  >;
+}) => {
+  const mutationOptions = getPostContextualRiskCategoriesIdLocalizationsMutationOptions(options);
 
   return useMutation(mutationOptions);
 };

--- a/client/src/types/generated/contextual-risk.ts
+++ b/client/src/types/generated/contextual-risk.ts
@@ -20,6 +20,8 @@ import type {
   ContextualRiskResponse,
   ContextualRiskRequest,
   GetContextualRisksIdParams,
+  ContextualRiskLocalizationResponse,
+  ContextualRiskLocalizationRequest,
 } from "./strapi.schemas";
 import { API } from "../../services/api/index";
 import type { ErrorType } from "../../services/api/index";
@@ -308,6 +310,69 @@ export const useDeleteContextualRisksId = <
   >;
 }) => {
   const mutationOptions = getDeleteContextualRisksIdMutationOptions(options);
+
+  return useMutation(mutationOptions);
+};
+export const postContextualRisksIdLocalizations = (
+  id: number,
+  contextualRiskLocalizationRequest: ContextualRiskLocalizationRequest,
+) => {
+  return API<ContextualRiskLocalizationResponse>({
+    url: `/contextual-risks/${id}/localizations`,
+    method: "post",
+    headers: { "Content-Type": "application/json" },
+    data: contextualRiskLocalizationRequest,
+  });
+};
+
+export const getPostContextualRisksIdLocalizationsMutationOptions = <
+  TError = ErrorType<Error>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postContextualRisksIdLocalizations>>,
+    TError,
+    { id: number; data: ContextualRiskLocalizationRequest },
+    TContext
+  >;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof postContextualRisksIdLocalizations>>,
+  TError,
+  { id: number; data: ContextualRiskLocalizationRequest },
+  TContext
+> => {
+  const { mutation: mutationOptions } = options ?? {};
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof postContextualRisksIdLocalizations>>,
+    { id: number; data: ContextualRiskLocalizationRequest }
+  > = (props) => {
+    const { id, data } = props ?? {};
+
+    return postContextualRisksIdLocalizations(id, data);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type PostContextualRisksIdLocalizationsMutationResult = NonNullable<
+  Awaited<ReturnType<typeof postContextualRisksIdLocalizations>>
+>;
+export type PostContextualRisksIdLocalizationsMutationBody = ContextualRiskLocalizationRequest;
+export type PostContextualRisksIdLocalizationsMutationError = ErrorType<Error>;
+
+export const usePostContextualRisksIdLocalizations = <
+  TError = ErrorType<Error>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postContextualRisksIdLocalizations>>,
+    TError,
+    { id: number; data: ContextualRiskLocalizationRequest },
+    TContext
+  >;
+}) => {
+  const mutationOptions = getPostContextualRisksIdLocalizationsMutationOptions(options);
 
   return useMutation(mutationOptions);
 };

--- a/client/src/types/generated/pcb-category.ts
+++ b/client/src/types/generated/pcb-category.ts
@@ -20,6 +20,8 @@ import type {
   PcbCategoryResponse,
   PcbCategoryRequest,
   GetPcbCategoriesIdParams,
+  PcbCategoryLocalizationResponse,
+  PcbCategoryLocalizationRequest,
 } from "./strapi.schemas";
 import { API } from "../../services/api/index";
 import type { ErrorType } from "../../services/api/index";
@@ -293,6 +295,69 @@ export const useDeletePcbCategoriesId = <TError = ErrorType<Error>, TContext = u
   >;
 }) => {
   const mutationOptions = getDeletePcbCategoriesIdMutationOptions(options);
+
+  return useMutation(mutationOptions);
+};
+export const postPcbCategoriesIdLocalizations = (
+  id: number,
+  pcbCategoryLocalizationRequest: PcbCategoryLocalizationRequest,
+) => {
+  return API<PcbCategoryLocalizationResponse>({
+    url: `/pcb-categories/${id}/localizations`,
+    method: "post",
+    headers: { "Content-Type": "application/json" },
+    data: pcbCategoryLocalizationRequest,
+  });
+};
+
+export const getPostPcbCategoriesIdLocalizationsMutationOptions = <
+  TError = ErrorType<Error>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postPcbCategoriesIdLocalizations>>,
+    TError,
+    { id: number; data: PcbCategoryLocalizationRequest },
+    TContext
+  >;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof postPcbCategoriesIdLocalizations>>,
+  TError,
+  { id: number; data: PcbCategoryLocalizationRequest },
+  TContext
+> => {
+  const { mutation: mutationOptions } = options ?? {};
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof postPcbCategoriesIdLocalizations>>,
+    { id: number; data: PcbCategoryLocalizationRequest }
+  > = (props) => {
+    const { id, data } = props ?? {};
+
+    return postPcbCategoriesIdLocalizations(id, data);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type PostPcbCategoriesIdLocalizationsMutationResult = NonNullable<
+  Awaited<ReturnType<typeof postPcbCategoriesIdLocalizations>>
+>;
+export type PostPcbCategoriesIdLocalizationsMutationBody = PcbCategoryLocalizationRequest;
+export type PostPcbCategoriesIdLocalizationsMutationError = ErrorType<Error>;
+
+export const usePostPcbCategoriesIdLocalizations = <
+  TError = ErrorType<Error>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postPcbCategoriesIdLocalizations>>,
+    TError,
+    { id: number; data: PcbCategoryLocalizationRequest },
+    TContext
+  >;
+}) => {
+  const mutationOptions = getPostPcbCategoriesIdLocalizationsMutationOptions(options);
 
   return useMutation(mutationOptions);
 };

--- a/client/src/types/generated/pcb.ts
+++ b/client/src/types/generated/pcb.ts
@@ -20,6 +20,8 @@ import type {
   PcbResponse,
   PcbRequest,
   GetPcbsIdParams,
+  PcbLocalizationResponse,
+  PcbLocalizationRequest,
 } from "./strapi.schemas";
 import { API } from "../../services/api/index";
 import type { ErrorType } from "../../services/api/index";
@@ -266,6 +268,69 @@ export const useDeletePcbsId = <TError = ErrorType<Error>, TContext = unknown>(o
   >;
 }) => {
   const mutationOptions = getDeletePcbsIdMutationOptions(options);
+
+  return useMutation(mutationOptions);
+};
+export const postPcbsIdLocalizations = (
+  id: number,
+  pcbLocalizationRequest: PcbLocalizationRequest,
+) => {
+  return API<PcbLocalizationResponse>({
+    url: `/pcbs/${id}/localizations`,
+    method: "post",
+    headers: { "Content-Type": "application/json" },
+    data: pcbLocalizationRequest,
+  });
+};
+
+export const getPostPcbsIdLocalizationsMutationOptions = <
+  TError = ErrorType<Error>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postPcbsIdLocalizations>>,
+    TError,
+    { id: number; data: PcbLocalizationRequest },
+    TContext
+  >;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof postPcbsIdLocalizations>>,
+  TError,
+  { id: number; data: PcbLocalizationRequest },
+  TContext
+> => {
+  const { mutation: mutationOptions } = options ?? {};
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof postPcbsIdLocalizations>>,
+    { id: number; data: PcbLocalizationRequest }
+  > = (props) => {
+    const { id, data } = props ?? {};
+
+    return postPcbsIdLocalizations(id, data);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type PostPcbsIdLocalizationsMutationResult = NonNullable<
+  Awaited<ReturnType<typeof postPcbsIdLocalizations>>
+>;
+export type PostPcbsIdLocalizationsMutationBody = PcbLocalizationRequest;
+export type PostPcbsIdLocalizationsMutationError = ErrorType<Error>;
+
+export const usePostPcbsIdLocalizations = <
+  TError = ErrorType<Error>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postPcbsIdLocalizations>>,
+    TError,
+    { id: number; data: PcbLocalizationRequest },
+    TContext
+  >;
+}) => {
+  const mutationOptions = getPostPcbsIdLocalizationsMutationOptions(options);
 
   return useMutation(mutationOptions);
 };

--- a/client/src/types/generated/project.ts
+++ b/client/src/types/generated/project.ts
@@ -20,6 +20,8 @@ import type {
   ProjectResponse,
   ProjectRequest,
   GetProjectsIdParams,
+  ProjectLocalizationResponse,
+  ProjectLocalizationRequest,
 } from "./strapi.schemas";
 import { API } from "../../services/api/index";
 import type { ErrorType } from "../../services/api/index";
@@ -275,6 +277,69 @@ export const useDeleteProjectsId = <TError = ErrorType<Error>, TContext = unknow
   >;
 }) => {
   const mutationOptions = getDeleteProjectsIdMutationOptions(options);
+
+  return useMutation(mutationOptions);
+};
+export const postProjectsIdLocalizations = (
+  id: number,
+  projectLocalizationRequest: ProjectLocalizationRequest,
+) => {
+  return API<ProjectLocalizationResponse>({
+    url: `/projects/${id}/localizations`,
+    method: "post",
+    headers: { "Content-Type": "application/json" },
+    data: projectLocalizationRequest,
+  });
+};
+
+export const getPostProjectsIdLocalizationsMutationOptions = <
+  TError = ErrorType<Error>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postProjectsIdLocalizations>>,
+    TError,
+    { id: number; data: ProjectLocalizationRequest },
+    TContext
+  >;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof postProjectsIdLocalizations>>,
+  TError,
+  { id: number; data: ProjectLocalizationRequest },
+  TContext
+> => {
+  const { mutation: mutationOptions } = options ?? {};
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof postProjectsIdLocalizations>>,
+    { id: number; data: ProjectLocalizationRequest }
+  > = (props) => {
+    const { id, data } = props ?? {};
+
+    return postProjectsIdLocalizations(id, data);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type PostProjectsIdLocalizationsMutationResult = NonNullable<
+  Awaited<ReturnType<typeof postProjectsIdLocalizations>>
+>;
+export type PostProjectsIdLocalizationsMutationBody = ProjectLocalizationRequest;
+export type PostProjectsIdLocalizationsMutationError = ErrorType<Error>;
+
+export const usePostProjectsIdLocalizations = <
+  TError = ErrorType<Error>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postProjectsIdLocalizations>>,
+    TError,
+    { id: number; data: ProjectLocalizationRequest },
+    TContext
+  >;
+}) => {
+  const mutationOptions = getPostProjectsIdLocalizationsMutationOptions(options);
 
   return useMutation(mutationOptions);
 };

--- a/client/src/types/generated/strapi.schemas.ts
+++ b/client/src/types/generated/strapi.schemas.ts
@@ -397,6 +397,30 @@ export interface ProjectResponse {
   meta?: ProjectResponseMeta;
 }
 
+export type ProjectLocalizations = {
+  data?: Project[];
+};
+
+export interface Project {
+  name: string;
+  description: string;
+  risks?: unknown;
+  author?: ProjectAuthor;
+  pcbs?: unknown;
+  createdAt?: string;
+  updatedAt?: string;
+  publishedAt?: string;
+  createdBy?: ProjectCreatedBy;
+  updatedBy?: ProjectUpdatedBy;
+  localizations?: ProjectLocalizations;
+  locale?: string;
+}
+
+export interface ProjectResponseDataObject {
+  id?: number;
+  attributes?: Project;
+}
+
 export type ProjectUpdatedByDataAttributes = { [key: string]: any };
 
 export type ProjectUpdatedByData = {
@@ -419,23 +443,16 @@ export type ProjectCreatedBy = {
   data?: ProjectCreatedByData;
 };
 
-export interface Project {
-  name: string;
-  description: string;
-  risks?: unknown;
-  author?: ProjectAuthor;
-  pcbs?: unknown;
-  createdAt?: string;
-  updatedAt?: string;
-  publishedAt?: string;
-  createdBy?: ProjectCreatedBy;
-  updatedBy?: ProjectUpdatedBy;
-}
-
-export interface ProjectResponseDataObject {
+export type ProjectAuthorData = {
   id?: number;
-  attributes?: Project;
-}
+  attributes?: ProjectAuthorDataAttributes;
+};
+
+export type ProjectAuthor = {
+  data?: ProjectAuthorData;
+};
+
+export type ProjectAuthorDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type ProjectAuthorDataAttributesUpdatedByData = {
   id?: number;
@@ -444,6 +461,17 @@ export type ProjectAuthorDataAttributesUpdatedByData = {
 
 export type ProjectAuthorDataAttributesUpdatedBy = {
   data?: ProjectAuthorDataAttributesUpdatedByData;
+};
+
+export type ProjectAuthorDataAttributesCreatedByDataAttributes = { [key: string]: any };
+
+export type ProjectAuthorDataAttributesCreatedByData = {
+  id?: number;
+  attributes?: ProjectAuthorDataAttributesCreatedByDataAttributes;
+};
+
+export type ProjectAuthorDataAttributesCreatedBy = {
+  data?: ProjectAuthorDataAttributesCreatedByData;
 };
 
 export type ProjectAuthorDataAttributes = {
@@ -461,26 +489,20 @@ export type ProjectAuthorDataAttributes = {
   updatedBy?: ProjectAuthorDataAttributesUpdatedBy;
 };
 
-export type ProjectAuthorData = {
-  id?: number;
-  attributes?: ProjectAuthorDataAttributes;
+export type ProjectAuthorDataAttributesRoleDataAttributesUpdatedBy = {
+  data?: ProjectAuthorDataAttributesRoleDataAttributesUpdatedByData;
 };
 
-export type ProjectAuthor = {
-  data?: ProjectAuthorData;
-};
-
-export type ProjectAuthorDataAttributesUpdatedByDataAttributes = { [key: string]: any };
-
-export type ProjectAuthorDataAttributesCreatedByDataAttributes = { [key: string]: any };
-
-export type ProjectAuthorDataAttributesCreatedByData = {
-  id?: number;
-  attributes?: ProjectAuthorDataAttributesCreatedByDataAttributes;
-};
-
-export type ProjectAuthorDataAttributesCreatedBy = {
-  data?: ProjectAuthorDataAttributesCreatedByData;
+export type ProjectAuthorDataAttributesRoleDataAttributes = {
+  name?: string;
+  description?: string;
+  type?: string;
+  permissions?: ProjectAuthorDataAttributesRoleDataAttributesPermissions;
+  users?: ProjectAuthorDataAttributesRoleDataAttributesUsers;
+  createdAt?: string;
+  updatedAt?: string;
+  createdBy?: ProjectAuthorDataAttributesRoleDataAttributesCreatedBy;
+  updatedBy?: ProjectAuthorDataAttributesRoleDataAttributesUpdatedBy;
 };
 
 export type ProjectAuthorDataAttributesRoleData = {
@@ -499,10 +521,6 @@ export type ProjectAuthorDataAttributesRoleDataAttributesUpdatedByDataAttributes
 export type ProjectAuthorDataAttributesRoleDataAttributesUpdatedByData = {
   id?: number;
   attributes?: ProjectAuthorDataAttributesRoleDataAttributesUpdatedByDataAttributes;
-};
-
-export type ProjectAuthorDataAttributesRoleDataAttributesUpdatedBy = {
-  data?: ProjectAuthorDataAttributesRoleDataAttributesUpdatedByData;
 };
 
 export type ProjectAuthorDataAttributesRoleDataAttributesCreatedByDataAttributes = {
@@ -531,32 +549,6 @@ export type ProjectAuthorDataAttributesRoleDataAttributesUsers = {
   data?: ProjectAuthorDataAttributesRoleDataAttributesUsersDataItem[];
 };
 
-export type ProjectAuthorDataAttributesRoleDataAttributes = {
-  name?: string;
-  description?: string;
-  type?: string;
-  permissions?: ProjectAuthorDataAttributesRoleDataAttributesPermissions;
-  users?: ProjectAuthorDataAttributesRoleDataAttributesUsers;
-  createdAt?: string;
-  updatedAt?: string;
-  createdBy?: ProjectAuthorDataAttributesRoleDataAttributesCreatedBy;
-  updatedBy?: ProjectAuthorDataAttributesRoleDataAttributesUpdatedBy;
-};
-
-export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributes = {
-  action?: string;
-  role?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesRole;
-  createdAt?: string;
-  updatedAt?: string;
-  createdBy?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedBy;
-  updatedBy?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesUpdatedBy;
-};
-
-export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItem = {
-  id?: number;
-  attributes?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributes;
-};
-
 export type ProjectAuthorDataAttributesRoleDataAttributesPermissions = {
   data?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItem[];
 };
@@ -573,6 +565,44 @@ export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttr
 export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesUpdatedBy = {
   data?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesUpdatedByData;
 };
+
+export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByData =
+  {
+    id?: number;
+    attributes?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributes;
+  };
+
+export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedBy = {
+  data?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByData;
+};
+
+export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributes = {
+  action?: string;
+  role?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesRole;
+  createdAt?: string;
+  updatedAt?: string;
+  createdBy?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedBy;
+  updatedBy?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesUpdatedBy;
+};
+
+export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItem = {
+  id?: number;
+  attributes?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributes;
+};
+
+export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesUpdatedByDataAttributes =
+  { [key: string]: any };
+
+export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesUpdatedByData =
+  {
+    id?: number;
+    attributes?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesUpdatedByDataAttributes;
+  };
+
+export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesUpdatedBy =
+  {
+    data?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesUpdatedByData;
+  };
 
 export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributes =
   {
@@ -592,30 +622,6 @@ export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttr
     updatedBy?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesUpdatedBy;
   };
 
-export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByData =
-  {
-    id?: number;
-    attributes?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributes;
-  };
-
-export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedBy = {
-  data?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByData;
-};
-
-export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
-
-export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesUpdatedByData =
-  {
-    id?: number;
-    attributes?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesUpdatedByDataAttributes;
-  };
-
-export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesUpdatedBy =
-  {
-    data?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesUpdatedByData;
-  };
-
 export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesCreatedByDataAttributes =
   { [key: string]: any };
 
@@ -628,19 +634,6 @@ export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttr
 export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesCreatedBy =
   {
     data?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesCreatedByData;
-  };
-
-export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributes =
-  {
-    name?: string;
-    code?: string;
-    description?: string;
-    users?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
-    permissions?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
-    createdAt?: string;
-    updatedAt?: string;
-    createdBy?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
-    updatedBy?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
   };
 
 export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItem =
@@ -682,20 +675,6 @@ export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttr
     data?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData;
   };
 
-export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes =
-  {
-    action?: string;
-    actionParameters?: unknown;
-    subject?: string;
-    properties?: unknown;
-    conditions?: unknown;
-    role?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
-    createdAt?: string;
-    updatedAt?: string;
-    createdBy?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
-    updatedBy?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
-  };
-
 export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem =
   {
     id?: number;
@@ -705,6 +684,19 @@ export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttr
 export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions =
   {
     data?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
+  };
+
+export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributes =
+  {
+    name?: string;
+    code?: string;
+    description?: string;
+    users?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
+    permissions?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
+    createdAt?: string;
+    updatedAt?: string;
+    createdBy?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
+    updatedBy?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
   };
 
 export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes =
@@ -747,6 +739,20 @@ export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttr
 export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole =
   {
     data?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
+  };
+
+export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes =
+  {
+    action?: string;
+    actionParameters?: unknown;
+    subject?: string;
+    properties?: unknown;
+    conditions?: unknown;
+    role?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
+    createdAt?: string;
+    updatedAt?: string;
+    createdBy?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
+    updatedBy?: ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
   };
 
 export type ProjectAuthorDataAttributesRoleDataAttributesPermissionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes =
@@ -796,6 +802,39 @@ export interface ProjectListResponse {
   meta?: ProjectListResponseMeta;
 }
 
+export type ProjectLocalizationListResponseMetaPagination = {
+  page?: number;
+  pageSize?: number;
+  pageCount?: number;
+  total?: number;
+};
+
+export type ProjectLocalizationListResponseMeta = {
+  pagination?: ProjectLocalizationListResponseMetaPagination;
+};
+
+export interface ProjectListResponseDataItemLocalized {
+  id?: number;
+  attributes?: Project;
+}
+
+export interface ProjectLocalizationListResponse {
+  data?: ProjectListResponseDataItemLocalized[];
+  meta?: ProjectLocalizationListResponseMeta;
+}
+
+export type ProjectLocalizationResponseMeta = { [key: string]: any };
+
+export interface ProjectResponseDataObjectLocalized {
+  id?: number;
+  attributes?: Project;
+}
+
+export interface ProjectLocalizationResponse {
+  data?: ProjectResponseDataObjectLocalized;
+  meta?: ProjectLocalizationResponseMeta;
+}
+
 export type ProjectRequestDataAuthor = number | string;
 
 export type ProjectRequestData = {
@@ -804,10 +843,22 @@ export type ProjectRequestData = {
   risks?: unknown;
   author?: ProjectRequestDataAuthor;
   pcbs?: unknown;
+  locale?: string;
 };
 
 export interface ProjectRequest {
   data: ProjectRequestData;
+}
+
+export type ProjectLocalizationRequestAuthor = number | string;
+
+export interface ProjectLocalizationRequest {
+  name: string;
+  description: string;
+  risks?: unknown;
+  author?: ProjectLocalizationRequestAuthor;
+  pcbs?: unknown;
+  locale: string;
 }
 
 export type PcbCategoryResponseMeta = { [key: string]: any };
@@ -821,6 +872,10 @@ export interface PcbCategoryResponse {
   data?: PcbCategoryResponseDataObject;
   meta?: PcbCategoryResponseMeta;
 }
+
+export type PcbCategoryLocalizations = {
+  data?: PcbCategory[];
+};
 
 export type PcbCategoryUpdatedByDataAttributes = { [key: string]: any };
 
@@ -844,6 +899,25 @@ export type PcbCategoryCreatedBy = {
   data?: PcbCategoryCreatedByData;
 };
 
+export type PcbCategoryPcbsDataItemAttributesLocalizations = {
+  data?: unknown[];
+};
+
+export type PcbCategoryPcbsDataItemAttributes = {
+  title?: string;
+  display_order?: number;
+  pcb_category?: PcbCategoryPcbsDataItemAttributesPcbCategory;
+  description?: string;
+  input?: unknown;
+  createdAt?: string;
+  updatedAt?: string;
+  publishedAt?: string;
+  createdBy?: PcbCategoryPcbsDataItemAttributesCreatedBy;
+  updatedBy?: PcbCategoryPcbsDataItemAttributesUpdatedBy;
+  localizations?: PcbCategoryPcbsDataItemAttributesLocalizations;
+  locale?: string;
+};
+
 export type PcbCategoryPcbsDataItem = {
   id?: number;
   attributes?: PcbCategoryPcbsDataItemAttributes;
@@ -864,6 +938,8 @@ export interface PcbCategory {
   publishedAt?: string;
   createdBy?: PcbCategoryCreatedBy;
   updatedBy?: PcbCategoryUpdatedBy;
+  localizations?: PcbCategoryLocalizations;
+  locale?: string;
 }
 
 export type PcbCategoryPcbsDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
@@ -888,26 +964,32 @@ export type PcbCategoryPcbsDataItemAttributesCreatedBy = {
   data?: PcbCategoryPcbsDataItemAttributesCreatedByData;
 };
 
-export type PcbCategoryPcbsDataItemAttributesPcbCategoryData = {
-  id?: number;
-  attributes?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributes;
-};
-
 export type PcbCategoryPcbsDataItemAttributesPcbCategory = {
   data?: PcbCategoryPcbsDataItemAttributesPcbCategoryData;
 };
 
-export type PcbCategoryPcbsDataItemAttributes = {
+export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesLocalizations = {
+  data?: unknown[];
+};
+
+export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributes = {
   title?: string;
   display_order?: number;
-  pcb_category?: PcbCategoryPcbsDataItemAttributesPcbCategory;
+  pcbs?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesPcbs;
   description?: string;
-  input?: unknown;
+  slug?: string;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
-  createdBy?: PcbCategoryPcbsDataItemAttributesCreatedBy;
-  updatedBy?: PcbCategoryPcbsDataItemAttributesUpdatedBy;
+  createdBy?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedBy;
+  updatedBy?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesUpdatedBy;
+  localizations?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesLocalizations;
+  locale?: string;
+};
+
+export type PcbCategoryPcbsDataItemAttributesPcbCategoryData = {
+  id?: number;
+  attributes?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributes;
 };
 
 export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesUpdatedByDataAttributes = {
@@ -922,53 +1004,6 @@ export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesUpdatedByD
 export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesUpdatedBy = {
   data?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesUpdatedByData;
 };
-
-export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByData = {
-  id?: number;
-  attributes?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributes;
-};
-
-export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedBy = {
-  data?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByData;
-};
-
-export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributes = {
-  title?: string;
-  display_order?: number;
-  pcbs?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesPcbs;
-  description?: string;
-  slug?: string;
-  createdAt?: string;
-  updatedAt?: string;
-  publishedAt?: string;
-  createdBy?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedBy;
-  updatedBy?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesUpdatedBy;
-};
-
-export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
-
-export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesUpdatedByData =
-  {
-    id?: number;
-    attributes?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesUpdatedByDataAttributes;
-  };
-
-export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesUpdatedBy =
-  {
-    data?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesUpdatedByData;
-  };
-
-export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesCreatedByData =
-  {
-    id?: number;
-    attributes?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesCreatedByDataAttributes;
-  };
-
-export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesCreatedBy =
-  {
-    data?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesCreatedByData;
-  };
 
 export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributes = {
   firstname?: string;
@@ -987,8 +1022,55 @@ export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByD
   updatedBy?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesUpdatedBy;
 };
 
+export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByData = {
+  id?: number;
+  attributes?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributes;
+};
+
+export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedBy = {
+  data?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByData;
+};
+
+export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesUpdatedByDataAttributes =
+  { [key: string]: any };
+
+export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesUpdatedByData =
+  {
+    id?: number;
+    attributes?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesUpdatedByDataAttributes;
+  };
+
+export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesUpdatedBy =
+  {
+    data?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesUpdatedByData;
+  };
+
 export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesCreatedByDataAttributes =
   { [key: string]: any };
+
+export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesCreatedByData =
+  {
+    id?: number;
+    attributes?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesCreatedByDataAttributes;
+  };
+
+export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesCreatedBy =
+  {
+    data?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesCreatedByData;
+  };
+
+export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributes =
+  {
+    name?: string;
+    code?: string;
+    description?: string;
+    users?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
+    permissions?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
+    createdAt?: string;
+    updatedAt?: string;
+    createdBy?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
+    updatedBy?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
+  };
 
 export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItem =
   {
@@ -1029,6 +1111,20 @@ export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByD
     data?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData;
   };
 
+export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes =
+  {
+    action?: string;
+    actionParameters?: unknown;
+    subject?: string;
+    properties?: unknown;
+    conditions?: unknown;
+    role?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
+    createdAt?: string;
+    updatedAt?: string;
+    createdBy?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
+    updatedBy?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
+  };
+
 export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem =
   {
     id?: number;
@@ -1038,19 +1134,6 @@ export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByD
 export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions =
   {
     data?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
-  };
-
-export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributes =
-  {
-    name?: string;
-    code?: string;
-    description?: string;
-    users?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
-    permissions?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
-    createdAt?: string;
-    updatedAt?: string;
-    createdBy?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
-    updatedBy?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
   };
 
 export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes =
@@ -1065,20 +1148,6 @@ export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByD
 export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy =
   {
     data?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
-  };
-
-export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes =
-  {
-    action?: string;
-    actionParameters?: unknown;
-    subject?: string;
-    properties?: unknown;
-    conditions?: unknown;
-    role?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
-    createdAt?: string;
-    updatedAt?: string;
-    createdBy?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
-    updatedBy?: PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
   };
 
 export type PcbCategoryPcbsDataItemAttributesPcbCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes =
@@ -1157,6 +1226,39 @@ export interface PcbCategoryListResponse {
   meta?: PcbCategoryListResponseMeta;
 }
 
+export type PcbCategoryLocalizationListResponseMetaPagination = {
+  page?: number;
+  pageSize?: number;
+  pageCount?: number;
+  total?: number;
+};
+
+export type PcbCategoryLocalizationListResponseMeta = {
+  pagination?: PcbCategoryLocalizationListResponseMetaPagination;
+};
+
+export interface PcbCategoryListResponseDataItemLocalized {
+  id?: number;
+  attributes?: PcbCategory;
+}
+
+export interface PcbCategoryLocalizationListResponse {
+  data?: PcbCategoryListResponseDataItemLocalized[];
+  meta?: PcbCategoryLocalizationListResponseMeta;
+}
+
+export type PcbCategoryLocalizationResponseMeta = { [key: string]: any };
+
+export interface PcbCategoryResponseDataObjectLocalized {
+  id?: number;
+  attributes?: PcbCategory;
+}
+
+export interface PcbCategoryLocalizationResponse {
+  data?: PcbCategoryResponseDataObjectLocalized;
+  meta?: PcbCategoryLocalizationResponseMeta;
+}
+
 export type PcbCategoryRequestDataPcbsItem = number | string;
 
 export type PcbCategoryRequestData = {
@@ -1165,22 +1267,53 @@ export type PcbCategoryRequestData = {
   pcbs?: PcbCategoryRequestDataPcbsItem[];
   description: string;
   slug?: string;
+  locale?: string;
 };
 
 export interface PcbCategoryRequest {
   data: PcbCategoryRequestData;
 }
 
-export type PcbResponseMeta = { [key: string]: any };
+export type PcbCategoryLocalizationRequestPcbsItem = number | string;
 
-export interface PcbResponseDataObject {
-  id?: number;
-  attributes?: Pcb;
+export interface PcbCategoryLocalizationRequest {
+  title: string;
+  display_order?: number;
+  pcbs?: PcbCategoryLocalizationRequestPcbsItem[];
+  description: string;
+  slug?: string;
+  locale: string;
 }
+
+export type PcbResponseMeta = { [key: string]: any };
 
 export interface PcbResponse {
   data?: PcbResponseDataObject;
   meta?: PcbResponseMeta;
+}
+
+export type PcbLocalizations = {
+  data?: Pcb[];
+};
+
+export interface Pcb {
+  title: string;
+  display_order?: number;
+  pcb_category?: PcbPcbCategory;
+  description: string;
+  input: unknown;
+  createdAt?: string;
+  updatedAt?: string;
+  publishedAt?: string;
+  createdBy?: PcbCreatedBy;
+  updatedBy?: PcbUpdatedBy;
+  localizations?: PcbLocalizations;
+  locale?: string;
+}
+
+export interface PcbResponseDataObject {
+  id?: number;
+  attributes?: Pcb;
 }
 
 export type PcbUpdatedByDataAttributes = { [key: string]: any };
@@ -1205,21 +1338,8 @@ export type PcbCreatedBy = {
   data?: PcbCreatedByData;
 };
 
-export interface Pcb {
-  title: string;
-  display_order?: number;
-  pcb_category?: PcbPcbCategory;
-  description: string;
-  input: unknown;
-  createdAt?: string;
-  updatedAt?: string;
-  publishedAt?: string;
-  createdBy?: PcbCreatedBy;
-  updatedBy?: PcbUpdatedBy;
-}
-
-export type PcbPcbCategoryDataAttributesUpdatedBy = {
-  data?: PcbPcbCategoryDataAttributesUpdatedByData;
+export type PcbPcbCategoryDataAttributesLocalizations = {
+  data?: unknown[];
 };
 
 export type PcbPcbCategoryDataAttributes = {
@@ -1233,6 +1353,8 @@ export type PcbPcbCategoryDataAttributes = {
   publishedAt?: string;
   createdBy?: PcbPcbCategoryDataAttributesCreatedBy;
   updatedBy?: PcbPcbCategoryDataAttributesUpdatedBy;
+  localizations?: PcbPcbCategoryDataAttributesLocalizations;
+  locale?: string;
 };
 
 export type PcbPcbCategoryData = {
@@ -1251,6 +1373,10 @@ export type PcbPcbCategoryDataAttributesUpdatedByData = {
   attributes?: PcbPcbCategoryDataAttributesUpdatedByDataAttributes;
 };
 
+export type PcbPcbCategoryDataAttributesUpdatedBy = {
+  data?: PcbPcbCategoryDataAttributesUpdatedByData;
+};
+
 export type PcbPcbCategoryDataAttributesCreatedByDataAttributes = { [key: string]: any };
 
 export type PcbPcbCategoryDataAttributesCreatedByData = {
@@ -1264,6 +1390,10 @@ export type PcbPcbCategoryDataAttributesCreatedBy = {
 
 export type PcbPcbCategoryDataAttributesPcbs = {
   data?: PcbPcbCategoryDataAttributesPcbsDataItem[];
+};
+
+export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesLocalizations = {
+  data?: unknown[];
 };
 
 export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesUpdatedByDataAttributes = {
@@ -1299,6 +1429,8 @@ export type PcbPcbCategoryDataAttributesPcbsDataItemAttributes = {
   publishedAt?: string;
   createdBy?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedBy;
   updatedBy?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesUpdatedBy;
+  localizations?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesLocalizations;
+  locale?: string;
 };
 
 export type PcbPcbCategoryDataAttributesPcbsDataItem = {
@@ -1317,23 +1449,6 @@ export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttri
 
 export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesUpdatedBy = {
   data?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesUpdatedByData;
-};
-
-export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributes = {
-  firstname?: string;
-  lastname?: string;
-  username?: string;
-  email?: string;
-  resetPasswordToken?: string;
-  registrationToken?: string;
-  isActive?: boolean;
-  roles?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRoles;
-  blocked?: boolean;
-  preferedLanguage?: string;
-  createdAt?: string;
-  updatedAt?: string;
-  createdBy?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesCreatedBy;
-  updatedBy?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesUpdatedBy;
 };
 
 export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesCreatedByDataAttributes =
@@ -1359,6 +1474,23 @@ export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttri
   data?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItem[];
 };
 
+export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributes = {
+  firstname?: string;
+  lastname?: string;
+  username?: string;
+  email?: string;
+  resetPasswordToken?: string;
+  registrationToken?: string;
+  isActive?: boolean;
+  roles?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRoles;
+  blocked?: boolean;
+  preferedLanguage?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  createdBy?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesCreatedBy;
+  updatedBy?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesUpdatedBy;
+};
+
 export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes =
   { [key: string]: any };
 
@@ -1371,6 +1503,19 @@ export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttri
 export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy =
   {
     data?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData;
+  };
+
+export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributes =
+  {
+    name?: string;
+    code?: string;
+    description?: string;
+    users?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
+    permissions?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
+    createdAt?: string;
+    updatedAt?: string;
+    createdBy?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
+    updatedBy?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
   };
 
 export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes =
@@ -1387,22 +1532,29 @@ export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttri
     data?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData;
   };
 
+export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes =
+  {
+    action?: string;
+    actionParameters?: unknown;
+    subject?: string;
+    properties?: unknown;
+    conditions?: unknown;
+    role?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
+    createdAt?: string;
+    updatedAt?: string;
+    createdBy?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
+    updatedBy?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
+  };
+
+export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem =
+  {
+    id?: number;
+    attributes?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes;
+  };
+
 export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions =
   {
     data?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
-  };
-
-export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributes =
-  {
-    name?: string;
-    code?: string;
-    description?: string;
-    users?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
-    permissions?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
-    createdAt?: string;
-    updatedAt?: string;
-    createdBy?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
-    updatedBy?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
   };
 
 export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes =
@@ -1445,26 +1597,6 @@ export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttri
 export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole =
   {
     data?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
-  };
-
-export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes =
-  {
-    action?: string;
-    actionParameters?: unknown;
-    subject?: string;
-    properties?: unknown;
-    conditions?: unknown;
-    role?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
-    createdAt?: string;
-    updatedAt?: string;
-    createdBy?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
-    updatedBy?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
-  };
-
-export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem =
-  {
-    id?: number;
-    attributes?: PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes;
   };
 
 export type PcbPcbCategoryDataAttributesPcbsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes =
@@ -1515,6 +1647,39 @@ export interface PcbListResponse {
   meta?: PcbListResponseMeta;
 }
 
+export type PcbLocalizationListResponseMetaPagination = {
+  page?: number;
+  pageSize?: number;
+  pageCount?: number;
+  total?: number;
+};
+
+export type PcbLocalizationListResponseMeta = {
+  pagination?: PcbLocalizationListResponseMetaPagination;
+};
+
+export interface PcbListResponseDataItemLocalized {
+  id?: number;
+  attributes?: Pcb;
+}
+
+export interface PcbLocalizationListResponse {
+  data?: PcbListResponseDataItemLocalized[];
+  meta?: PcbLocalizationListResponseMeta;
+}
+
+export type PcbLocalizationResponseMeta = { [key: string]: any };
+
+export interface PcbResponseDataObjectLocalized {
+  id?: number;
+  attributes?: Pcb;
+}
+
+export interface PcbLocalizationResponse {
+  data?: PcbResponseDataObjectLocalized;
+  meta?: PcbLocalizationResponseMeta;
+}
+
 export type PcbRequestDataPcbCategory = number | string;
 
 export type PcbRequestData = {
@@ -1523,10 +1688,22 @@ export type PcbRequestData = {
   pcb_category?: PcbRequestDataPcbCategory;
   description: string;
   input: unknown;
+  locale?: string;
 };
 
 export interface PcbRequest {
   data: PcbRequestData;
+}
+
+export type PcbLocalizationRequestPcbCategory = number | string;
+
+export interface PcbLocalizationRequest {
+  title: string;
+  display_order?: number;
+  pcb_category?: PcbLocalizationRequestPcbCategory;
+  description: string;
+  input: unknown;
+  locale: string;
 }
 
 export type ContextualRiskCategoryResponseMeta = { [key: string]: any };
@@ -1540,6 +1717,10 @@ export interface ContextualRiskCategoryResponse {
   data?: ContextualRiskCategoryResponseDataObject;
   meta?: ContextualRiskCategoryResponseMeta;
 }
+
+export type ContextualRiskCategoryLocalizations = {
+  data?: ContextualRiskCategory[];
+};
 
 export type ContextualRiskCategoryUpdatedByDataAttributes = { [key: string]: any };
 
@@ -1563,28 +1744,6 @@ export type ContextualRiskCategoryCreatedBy = {
   data?: ContextualRiskCategoryCreatedByData;
 };
 
-export type ContextualRiskCategoryContextualRisksDataItemAttributes = {
-  title?: string;
-  description?: string;
-  display_order?: number;
-  contextual_risk_category?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategory;
-  project_risk_description?: string;
-  createdAt?: string;
-  updatedAt?: string;
-  publishedAt?: string;
-  createdBy?: ContextualRiskCategoryContextualRisksDataItemAttributesCreatedBy;
-  updatedBy?: ContextualRiskCategoryContextualRisksDataItemAttributesUpdatedBy;
-};
-
-export type ContextualRiskCategoryContextualRisksDataItem = {
-  id?: number;
-  attributes?: ContextualRiskCategoryContextualRisksDataItemAttributes;
-};
-
-export type ContextualRiskCategoryContextualRisks = {
-  data?: ContextualRiskCategoryContextualRisksDataItem[];
-};
-
 export interface ContextualRiskCategory {
   title: string;
   description: string;
@@ -1596,7 +1755,37 @@ export interface ContextualRiskCategory {
   publishedAt?: string;
   createdBy?: ContextualRiskCategoryCreatedBy;
   updatedBy?: ContextualRiskCategoryUpdatedBy;
+  localizations?: ContextualRiskCategoryLocalizations;
+  locale?: string;
 }
+
+export type ContextualRiskCategoryContextualRisksDataItemAttributesLocalizations = {
+  data?: unknown[];
+};
+
+export type ContextualRiskCategoryContextualRisksDataItemAttributes = {
+  title?: string;
+  description?: string;
+  display_order?: number;
+  contextual_risk_category?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategory;
+  project_risk_description?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  publishedAt?: string;
+  createdBy?: ContextualRiskCategoryContextualRisksDataItemAttributesCreatedBy;
+  updatedBy?: ContextualRiskCategoryContextualRisksDataItemAttributesUpdatedBy;
+  localizations?: ContextualRiskCategoryContextualRisksDataItemAttributesLocalizations;
+  locale?: string;
+};
+
+export type ContextualRiskCategoryContextualRisksDataItem = {
+  id?: number;
+  attributes?: ContextualRiskCategoryContextualRisksDataItemAttributes;
+};
+
+export type ContextualRiskCategoryContextualRisks = {
+  data?: ContextualRiskCategoryContextualRisksDataItem[];
+};
 
 export type ContextualRiskCategoryContextualRisksDataItemAttributesUpdatedByDataAttributes = {
   [key: string]: any;
@@ -1623,6 +1812,20 @@ export type ContextualRiskCategoryContextualRisksDataItemAttributesCreatedByData
 export type ContextualRiskCategoryContextualRisksDataItemAttributesCreatedBy = {
   data?: ContextualRiskCategoryContextualRisksDataItemAttributesCreatedByData;
 };
+
+export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryData = {
+  id?: number;
+  attributes?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributes;
+};
+
+export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategory = {
+  data?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryData;
+};
+
+export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesLocalizations =
+  {
+    data?: unknown[];
+  };
 
 export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesUpdatedByDataAttributes =
   { [key: string]: any };
@@ -1661,16 +1864,9 @@ export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRis
     publishedAt?: string;
     createdBy?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedBy;
     updatedBy?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesUpdatedBy;
+    localizations?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesLocalizations;
+    locale?: string;
   };
-
-export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryData = {
-  id?: number;
-  attributes?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributes;
-};
-
-export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategory = {
-  data?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryData;
-};
 
 export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesUpdatedByDataAttributes =
   { [key: string]: any };
@@ -1698,19 +1894,6 @@ export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRis
 export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesCreatedBy =
   {
     data?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesCreatedByData;
-  };
-
-export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributes =
-  {
-    name?: string;
-    code?: string;
-    description?: string;
-    users?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
-    permissions?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
-    createdAt?: string;
-    updatedAt?: string;
-    createdBy?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
-    updatedBy?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
   };
 
 export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItem =
@@ -1781,6 +1964,19 @@ export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRis
     data?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
   };
 
+export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributes =
+  {
+    name?: string;
+    code?: string;
+    description?: string;
+    users?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
+    permissions?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
+    createdAt?: string;
+    updatedAt?: string;
+    createdBy?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
+    updatedBy?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
+  };
+
 export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes =
   { [key: string]: any };
 
@@ -1795,9 +1991,6 @@ export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRis
     data?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
   };
 
-export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
-
 export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData =
   {
     id?: number;
@@ -1807,20 +2000,6 @@ export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRis
 export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy =
   {
     data?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData;
-  };
-
-export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes =
-  { [key: string]: any };
-
-export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData =
-  {
-    id?: number;
-    attributes?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes;
-  };
-
-export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole =
-  {
-    data?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
   };
 
 export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes =
@@ -1835,6 +2014,23 @@ export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRis
     updatedAt?: string;
     createdBy?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
     updatedBy?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
+  };
+
+export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes =
+  { [key: string]: any };
+
+export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes =
+  { [key: string]: any };
+
+export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData =
+  {
+    id?: number;
+    attributes?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes;
+  };
+
+export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole =
+  {
+    data?: ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
   };
 
 export type ContextualRiskCategoryContextualRisksDataItemAttributesContextualRiskCategoryDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes =
@@ -1886,6 +2082,39 @@ export interface ContextualRiskCategoryListResponse {
   meta?: ContextualRiskCategoryListResponseMeta;
 }
 
+export type ContextualRiskCategoryLocalizationListResponseMetaPagination = {
+  page?: number;
+  pageSize?: number;
+  pageCount?: number;
+  total?: number;
+};
+
+export type ContextualRiskCategoryLocalizationListResponseMeta = {
+  pagination?: ContextualRiskCategoryLocalizationListResponseMetaPagination;
+};
+
+export interface ContextualRiskCategoryListResponseDataItemLocalized {
+  id?: number;
+  attributes?: ContextualRiskCategory;
+}
+
+export interface ContextualRiskCategoryLocalizationListResponse {
+  data?: ContextualRiskCategoryListResponseDataItemLocalized[];
+  meta?: ContextualRiskCategoryLocalizationListResponseMeta;
+}
+
+export type ContextualRiskCategoryLocalizationResponseMeta = { [key: string]: any };
+
+export interface ContextualRiskCategoryResponseDataObjectLocalized {
+  id?: number;
+  attributes?: ContextualRiskCategory;
+}
+
+export interface ContextualRiskCategoryLocalizationResponse {
+  data?: ContextualRiskCategoryResponseDataObjectLocalized;
+  meta?: ContextualRiskCategoryLocalizationResponseMeta;
+}
+
 export type ContextualRiskCategoryRequestDataContextualRisksItem = number | string;
 
 export type ContextualRiskCategoryRequestData = {
@@ -1894,10 +2123,22 @@ export type ContextualRiskCategoryRequestData = {
   display_order?: number;
   contextual_risks?: ContextualRiskCategoryRequestDataContextualRisksItem[];
   slug?: string;
+  locale?: string;
 };
 
 export interface ContextualRiskCategoryRequest {
   data: ContextualRiskCategoryRequestData;
+}
+
+export type ContextualRiskCategoryLocalizationRequestContextualRisksItem = number | string;
+
+export interface ContextualRiskCategoryLocalizationRequest {
+  title: string;
+  description: string;
+  display_order?: number;
+  contextual_risks?: ContextualRiskCategoryLocalizationRequestContextualRisksItem[];
+  slug?: string;
+  locale: string;
 }
 
 export type ContextualRiskResponseMeta = { [key: string]: any };
@@ -1911,6 +2152,10 @@ export interface ContextualRiskResponse {
   data?: ContextualRiskResponseDataObject;
   meta?: ContextualRiskResponseMeta;
 }
+
+export type ContextualRiskLocalizations = {
+  data?: ContextualRisk[];
+};
 
 export type ContextualRiskUpdatedByDataAttributes = { [key: string]: any };
 
@@ -1934,19 +2179,6 @@ export type ContextualRiskCreatedBy = {
   data?: ContextualRiskCreatedByData;
 };
 
-export type ContextualRiskContextualRiskCategoryDataAttributes = {
-  title?: string;
-  description?: string;
-  display_order?: number;
-  contextual_risks?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisks;
-  slug?: string;
-  createdAt?: string;
-  updatedAt?: string;
-  publishedAt?: string;
-  createdBy?: ContextualRiskContextualRiskCategoryDataAttributesCreatedBy;
-  updatedBy?: ContextualRiskContextualRiskCategoryDataAttributesUpdatedBy;
-};
-
 export type ContextualRiskContextualRiskCategoryData = {
   id?: number;
   attributes?: ContextualRiskContextualRiskCategoryDataAttributes;
@@ -1967,7 +2199,13 @@ export interface ContextualRisk {
   publishedAt?: string;
   createdBy?: ContextualRiskCreatedBy;
   updatedBy?: ContextualRiskUpdatedBy;
+  localizations?: ContextualRiskLocalizations;
+  locale?: string;
 }
+
+export type ContextualRiskContextualRiskCategoryDataAttributesLocalizations = {
+  data?: unknown[];
+};
 
 export type ContextualRiskContextualRiskCategoryDataAttributesUpdatedByDataAttributes = {
   [key: string]: any;
@@ -1995,6 +2233,35 @@ export type ContextualRiskContextualRiskCategoryDataAttributesCreatedBy = {
   data?: ContextualRiskContextualRiskCategoryDataAttributesCreatedByData;
 };
 
+export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItem = {
+  id?: number;
+  attributes?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributes;
+};
+
+export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisks = {
+  data?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItem[];
+};
+
+export type ContextualRiskContextualRiskCategoryDataAttributes = {
+  title?: string;
+  description?: string;
+  display_order?: number;
+  contextual_risks?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisks;
+  slug?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  publishedAt?: string;
+  createdBy?: ContextualRiskContextualRiskCategoryDataAttributesCreatedBy;
+  updatedBy?: ContextualRiskContextualRiskCategoryDataAttributesUpdatedBy;
+  localizations?: ContextualRiskContextualRiskCategoryDataAttributesLocalizations;
+  locale?: string;
+};
+
+export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesLocalizations =
+  {
+    data?: unknown[];
+  };
+
 export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesUpdatedByDataAttributes =
   { [key: string]: any };
 
@@ -2009,6 +2276,17 @@ export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDat
     data?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesUpdatedByData;
   };
 
+export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByData =
+  {
+    id?: number;
+    attributes?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributes;
+  };
+
+export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedBy =
+  {
+    data?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByData;
+  };
+
 export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributes = {
   title?: string;
   description?: string;
@@ -2020,26 +2298,26 @@ export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDat
   publishedAt?: string;
   createdBy?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedBy;
   updatedBy?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesUpdatedBy;
+  localizations?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesLocalizations;
+  locale?: string;
 };
 
-export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItem = {
-  id?: number;
-  attributes?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributes;
-};
-
-export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisks = {
-  data?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItem[];
-};
-
-export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByData =
+export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributes =
   {
-    id?: number;
-    attributes?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributes;
-  };
-
-export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedBy =
-  {
-    data?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByData;
+    firstname?: string;
+    lastname?: string;
+    username?: string;
+    email?: string;
+    resetPasswordToken?: string;
+    registrationToken?: string;
+    isActive?: boolean;
+    roles?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRoles;
+    blocked?: boolean;
+    preferedLanguage?: string;
+    createdAt?: string;
+    updatedAt?: string;
+    createdBy?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesCreatedBy;
+    updatedBy?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesUpdatedBy;
   };
 
 export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesUpdatedByDataAttributes =
@@ -2081,24 +2359,6 @@ export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDat
     data?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItem[];
   };
 
-export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributes =
-  {
-    firstname?: string;
-    lastname?: string;
-    username?: string;
-    email?: string;
-    resetPasswordToken?: string;
-    registrationToken?: string;
-    isActive?: boolean;
-    roles?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRoles;
-    blocked?: boolean;
-    preferedLanguage?: string;
-    createdAt?: string;
-    updatedAt?: string;
-    createdBy?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesCreatedBy;
-    updatedBy?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesUpdatedBy;
-  };
-
 export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes =
   { [key: string]: any };
 
@@ -2111,19 +2371,6 @@ export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDat
 export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy =
   {
     data?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData;
-  };
-
-export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributes =
-  {
-    name?: string;
-    code?: string;
-    description?: string;
-    users?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
-    permissions?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
-    createdAt?: string;
-    updatedAt?: string;
-    createdBy?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
-    updatedBy?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
   };
 
 export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes =
@@ -2140,20 +2387,6 @@ export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDat
     data?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData;
   };
 
-export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes =
-  {
-    action?: string;
-    actionParameters?: unknown;
-    subject?: string;
-    properties?: unknown;
-    conditions?: unknown;
-    role?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
-    createdAt?: string;
-    updatedAt?: string;
-    createdBy?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
-    updatedBy?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
-  };
-
 export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem =
   {
     id?: number;
@@ -2163,6 +2396,19 @@ export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDat
 export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions =
   {
     data?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
+  };
+
+export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributes =
+  {
+    name?: string;
+    code?: string;
+    description?: string;
+    users?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
+    permissions?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
+    createdAt?: string;
+    updatedAt?: string;
+    createdBy?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
+    updatedBy?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
   };
 
 export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes =
@@ -2177,6 +2423,20 @@ export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDat
 export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy =
   {
     data?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
+  };
+
+export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes =
+  {
+    action?: string;
+    actionParameters?: unknown;
+    subject?: string;
+    properties?: unknown;
+    conditions?: unknown;
+    role?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
+    createdAt?: string;
+    updatedAt?: string;
+    createdBy?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
+    updatedBy?: ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
   };
 
 export type ContextualRiskContextualRiskCategoryDataAttributesContextualRisksDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes =
@@ -2256,6 +2516,39 @@ export interface ContextualRiskListResponse {
   meta?: ContextualRiskListResponseMeta;
 }
 
+export type ContextualRiskLocalizationListResponseMetaPagination = {
+  page?: number;
+  pageSize?: number;
+  pageCount?: number;
+  total?: number;
+};
+
+export type ContextualRiskLocalizationListResponseMeta = {
+  pagination?: ContextualRiskLocalizationListResponseMetaPagination;
+};
+
+export interface ContextualRiskListResponseDataItemLocalized {
+  id?: number;
+  attributes?: ContextualRisk;
+}
+
+export interface ContextualRiskLocalizationListResponse {
+  data?: ContextualRiskListResponseDataItemLocalized[];
+  meta?: ContextualRiskLocalizationListResponseMeta;
+}
+
+export type ContextualRiskLocalizationResponseMeta = { [key: string]: any };
+
+export interface ContextualRiskResponseDataObjectLocalized {
+  id?: number;
+  attributes?: ContextualRisk;
+}
+
+export interface ContextualRiskLocalizationResponse {
+  data?: ContextualRiskResponseDataObjectLocalized;
+  meta?: ContextualRiskLocalizationResponseMeta;
+}
+
 export type ContextualRiskRequestDataContextualRiskCategory = number | string;
 
 export type ContextualRiskRequestData = {
@@ -2264,10 +2557,22 @@ export type ContextualRiskRequestData = {
   display_order: number;
   contextual_risk_category?: ContextualRiskRequestDataContextualRiskCategory;
   project_risk_description: string;
+  locale?: string;
 };
 
 export interface ContextualRiskRequest {
   data: ContextualRiskRequestData;
+}
+
+export type ContextualRiskLocalizationRequestContextualRiskCategory = number | string;
+
+export interface ContextualRiskLocalizationRequest {
+  title: string;
+  description: string;
+  display_order: number;
+  contextual_risk_category?: ContextualRiskLocalizationRequestContextualRiskCategory;
+  project_risk_description: string;
+  locale: string;
 }
 
 export type ErrorErrorDetails = { [key: string]: any };


### PR DESCRIPTION
Add Spanish language to Strapi cms via Internationalization plugin.
Translations enabled for all collection types and fields, except numeric `display order` fields